### PR TITLE
Change http links to e.g. planet.osm.org to https.

### DIFF
--- a/osmhm/fetch.py
+++ b/osmhm/fetch.py
@@ -56,13 +56,13 @@ def fetch_next(current_sequence='', time_type='hour', reset=False):
 
     """
     if reset is True:
-        state_url = ("http://planet.openstreetmap.org/replication/"
+        state_url = ("https://planet.openstreetmap.org/replication/"
                      "%s/state.txt") % (time_type)
 
     else:
         next_sequence = int(current_sequence) + 1
         sequence_string = str(next_sequence).zfill(9)
-        state_url = ("http://planet.openstreetmap.org/replication/"
+        state_url = ("https://planet.openstreetmap.org/replication/"
                      "%s/%s/%s/%s.state.txt") % (time_type,
                          sequence_string[0:3], sequence_string[3:6],
                          sequence_string[6:9])

--- a/osmhm/send_notification.py
+++ b/osmhm/send_notification.py
@@ -29,8 +29,8 @@ OSM Hall Monitor has detected an event for your consideration.
 
   **User alert**
        Time of event: %s
-       Username: http://www.osm.org/user/%s
-       Changeset: http://www.osm.org/changeset/%s
+       Username: https://www.openstreetmap.org/user/%s
+       Changeset: https://www.openstreetmap.org/changeset/%s
        Additions: %s
        Modifications: %s
        Deletions: %s
@@ -65,10 +65,10 @@ OSM Hall Monitor has detected an event for your consideration.
 
   **Object alert**
        Time of event: %s
-       Object: http://www.osm.org/%s/%s
-       Changeset: http://www.osm.org/changeset/%s
+       Object: https://www.openstreetmap.org/%s/%s
+       Changeset: https://www.openstreetmap.org/changeset/%s
        Action: %s
-       User performing: http://www.osm.org/user/%s
+       User performing: https://www.openstreetmap.org/user/%s
        Reason object is watched: %s
 
 Problem? Feedback? Reply to this message.


### PR DESCRIPTION
Also expand osm.org to openstreetmap.org (so that the cert will match before doing any redirect).

OSM sites have been https only for some time now.  While it's possible that this code might follow redirects OK, it makes sense to change.

Currently the front end "OSM Hall Monitor" does not work - I'm guessing that that is an http vs https issue elsewhere), but can't see where that actually is.